### PR TITLE
Replace librosa with torchaudio for resampling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir \
     accelerate \
     soundfile \
-    librosa \
+    torchaudio==2.5.1 \
     fastapi \
     uvicorn \
     python-multipart \


### PR DESCRIPTION
Closes #12

## What
Replace `librosa.resample()` with `torchaudio.transforms.Resample()` in `preprocess_audio()`. torchaudio ships with PyTorch, eliminating the heavy librosa dependency (and its transitive deps: numba, llvmlite, scipy).

**Changes:**
- `src/server.py`: Swap librosa resampling for torchaudio `Resample` transform
- `Dockerfile`: Replace `librosa` with `torchaudio==2.5.1` in pip install

## Test
```bash
# Upload a 44.1kHz or 48kHz audio file — should auto-resample correctly
curl -X POST http://localhost:8100/v1/audio/transcriptions -F "file=@audio_44k.wav"
# Expected: correct transcription, no librosa import in logs
```