### PR TITLE
[Enhancement] Add OMP/MKL thread env vars to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ WORKDIR /app
 ENV PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
 # Disable tokenizer parallelism warnings in forked workers
 ENV TOKENIZERS_PARALLELISM=false
+# Prevent OpenMP/MKL from spawning CPU threads that compete with GPU inference
+ENV OMP_NUM_THREADS=1
+ENV MKL_NUM_THREADS=1
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/src/server_test.py
+++ b/src/server_test.py
@@ -36,3 +36,14 @@
 #   curl -X POST http://localhost:8100/v1/audio/transcriptions -F "file=@audio.wav"
 #   # Compare transcription quality — should be identical or near-identical
 # Expected: Faster inference with no meaningful accuracy degradation.
+
+# ─── Issue #13: OMP/MKL thread env vars ─────────────────────────────────────
+# Change: Added OMP_NUM_THREADS=1 and MKL_NUM_THREADS=1 to Dockerfile ENV.
+#         Prevents OpenMP/MKL from spawning CPU threads that compete with
+#         GPU inference, reducing context-switch overhead.
+# Verify:
+#   docker compose up -d --build
+#   docker exec <container> env | grep -E "OMP|MKL"
+#   # Expected: OMP_NUM_THREADS=1 and MKL_NUM_THREADS=1
+#   curl -X POST http://localhost:8100/v1/audio/transcriptions -F "file=@audio.wav"
+# Expected: Transcription works normally. No CPU thread contention during GPU inference.


### PR DESCRIPTION
Closes #13

## What
Added `OMP_NUM_THREADS=1` and `MKL_NUM_THREADS=1` environment variables to the Dockerfile. This prevents OpenMP/MKL from spawning CPU threads that compete with GPU inference, reducing context-switch overhead.

## Test
```bash
docker compose up -d --build
docker exec <container> env | grep -E "OMP|MKL"
# Expected: OMP_NUM_THREADS=1 and MKL_NUM_THREADS=1
curl -X POST http://localhost:8100/v1/audio/transcriptions -F "file=@audio.wav"
```

Tests: 0 passed, 0 failed, 0 skipped (manual verification only)