### PR TITLE
Warmup with representative audio instead of silence

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -129,7 +129,9 @@ def _load_model_sync():
     # Warmup inference to trigger CUDA kernel caching
     if torch.cuda.is_available():
         print("Warming up GPU...")
-        dummy = np.zeros(TARGET_SR, dtype=np.float32)  # 1 second of silence
+        # Use low-amplitude noise (better than silence for CUDA kernel caching)
+        rng = np.random.default_rng(seed=42)
+        dummy = rng.standard_normal(TARGET_SR).astype(np.float32) * 0.01
         try:
             model.transcribe((dummy, TARGET_SR))
         except Exception:


### PR DESCRIPTION
Closes #19

## What
Replace the zeros-based GPU warmup with low-amplitude random noise (seed=42, amplitude 0.01) that exercises more CUDA kernel code paths than pure silence, reducing first-request latency.

**Changes:**
- `src/server.py`: Replace `np.zeros()` warmup dummy with `np.random.default_rng(42).standard_normal() * 0.01`

## Test
```bash
# Check docker logs for warmup success
docker compose logs -f
# Expected: "Warming up GPU..." with no errors
# First request should be faster than before (warmup covers more kernel paths)
```