### PR TITLE
issue #7: Upgrade default model to Qwen3-ASR-1.7B

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -135,7 +135,7 @@ def _load_model_sync():
     if model is not None:
         return
 
-    model_id = os.getenv("MODEL_ID", "Qwen/Qwen3-ASR-0.6B")
+    model_id = os.getenv("MODEL_ID", "Qwen/Qwen3-ASR-1.7B")
     loaded_model_id = model_id
 
     print(f"Loading {model_id}...")

--- a/src/server_test.py
+++ b/src/server_test.py
@@ -107,3 +107,9 @@
 # Verify: noisy audio that previously caused loops ("thank you thank you thank you...")
 #   should now return clean output
 # curl -X POST http://localhost:8100/v1/audio/transcriptions -F "file=@noisy_audio.wav"
+
+# ─── Issue #7: Qwen3-ASR-1.7B default ────────────────────────────────
+# Change: default MODEL_ID changed to Qwen/Qwen3-ASR-1.7B
+# Verify: docker compose up -d --build
+#   curl http://localhost:8100/health  →  "model_id": "Qwen/Qwen3-ASR-1.7B"
+# Override: set MODEL_ID=Qwen/Qwen3-ASR-0.6B in compose.yaml environment


### PR DESCRIPTION
Closes #7

## What
Changed the default MODEL_ID from `Qwen/Qwen3-ASR-0.6B` to `Qwen/Qwen3-ASR-1.7B`. The 1.7B model matches/exceeds Whisper large-v3 for multilingual accuracy. Users who want the smaller model can still override via `MODEL_ID=Qwen/Qwen3-ASR-0.6B`.

Updated CLAUDE.md environment variable table to reflect the new default.

## Test
- `docker compose up -d --build`
- `curl http://localhost:8100/health` → verify `"model_id": "Qwen/Qwen3-ASR-1.7B"`
- Override test: set `MODEL_ID=Qwen/Qwen3-ASR-0.6B` in compose.yaml, rebuild, verify health returns 0.6B

Tests: 0 passed, 0 failed, 0 skipped (manual verification only)