### PR TITLE
issue #26: Reduce WebSocket buffer from 800ms to ~450ms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,8 @@ All server logic lives in `src/server.py` (~545 lines). Key subsystems:
 
 ### WebSocket Real-Time Transcription (`/ws/transcribe`)
 - Accepts raw PCM: 16-bit little-endian, 16kHz, mono
-- Buffers ~800ms of audio before transcribing (`WS_BUFFER_SIZE`)
-- **Overlap**: Last 300ms of each chunk is prepended to the next chunk to prevent word splits at boundaries (`WS_OVERLAP_SIZE`)
+- Buffers ~450ms of audio before transcribing (`WS_BUFFER_SIZE`)
+- **Overlap**: Last 150ms of each chunk is prepended to the next chunk to prevent word splits at boundaries (`WS_OVERLAP_SIZE`)
 - **Flush silence padding**: 600ms of silence appended before final transcription on `flush` command to help the model commit trailing words (`WS_FLUSH_SILENCE_MS`)
 - Control messages: `flush` (process remaining buffer), `reset` (clear state), `config` (set language)
 - Buffer is transcribed on client disconnect (no audio loss)
@@ -74,8 +74,8 @@ Input audio → mono conversion → float32 normalization → resample to 16kHz 
 | `MODEL_ID` | `Qwen/Qwen3-ASR-0.6B` | HuggingFace model (1.7B gives better multilingual accuracy) |
 | `IDLE_TIMEOUT` | `120` | Seconds before model unloads from GPU (0 = keep loaded) |
 | `REQUEST_TIMEOUT` | `300` | Max inference time per request |
-| `WS_BUFFER_SIZE` | `25600` | WebSocket audio buffer (~800ms at 16kHz) |
-| `WS_OVERLAP_SIZE` | `9600` | Overlap between chunks (~300ms) |
+| `WS_BUFFER_SIZE` | `14400` | WebSocket audio buffer (~450ms at 16kHz) |
+| `WS_OVERLAP_SIZE` | `4800` | Overlap between chunks (~150ms) |
 | `WS_FLUSH_SILENCE_MS` | `600` | Silence padding on flush |
 
 Port mapping: container 8000 → host 8100.

--- a/src/server.py
+++ b/src/server.py
@@ -63,13 +63,13 @@ _PINNED_BUFFER_SIZE = TARGET_SR * 30  # 480000 samples
 _cuda_stream: torch.cuda.Stream | None = None
 
 # ── WebSocket streaming config ──────────────────────────────────────────────
-# Buffer size: how much audio to accumulate before transcribing (~800ms default)
-# At 16kHz 16-bit mono: 800ms = 25600 bytes
-WS_BUFFER_SIZE = int(os.getenv("WS_BUFFER_SIZE", str(int(TARGET_SR * 2 * 0.8))))
+# Buffer size: how much audio to accumulate before transcribing (~450ms default)
+# At 16kHz 16-bit mono: 450ms = 14400 bytes
+WS_BUFFER_SIZE = int(os.getenv("WS_BUFFER_SIZE", str(int(TARGET_SR * 2 * 0.45))))
 
-# Overlap: how much of the previous chunk to prepend to the next (~300ms default)
+# Overlap: how much of the previous chunk to prepend to the next (~150ms default)
 # Prevents words from being split at chunk boundaries
-WS_OVERLAP_SIZE = int(os.getenv("WS_OVERLAP_SIZE", str(int(TARGET_SR * 2 * 0.3))))
+WS_OVERLAP_SIZE = int(os.getenv("WS_OVERLAP_SIZE", str(int(TARGET_SR * 2 * 0.15))))
 
 # Silence padding appended before final transcription on flush (~600ms)
 # Gives the model trailing context to commit the last word
@@ -451,7 +451,7 @@ async def websocket_transcribe(websocket: WebSocket):
     WebSocket endpoint for real-time audio transcription.
 
     Accepts binary audio frames (PCM 16-bit, 16kHz mono).
-    Buffers audio and transcribes in ~800ms windows with 300ms overlap
+    Buffers audio and transcribes in ~450ms windows with 150ms overlap
     between consecutive chunks to prevent word splits at boundaries.
 
     Client can send:

--- a/src/server_test.py
+++ b/src/server_test.py
@@ -144,3 +144,9 @@
 # Verify: docker compose logs | grep "CUDA inference stream"
 # Expected: "CUDA inference stream created"
 # Benefit: enables async transfer/compute overlap (measurable with CUDA profiler)
+
+# ─── Issue #26: Reduce WebSocket buffer from 800ms to 450ms ──────────
+# Change: WS_BUFFER_SIZE default changed from 25600 to 14400 (~450ms)
+#         WS_OVERLAP_SIZE default changed from 9600 to 4800 (~150ms)
+# Verify: WebSocket streaming still works with lower latency
+# Expected: faster partial transcriptions, same accuracy


### PR DESCRIPTION
Closes #26

## What
- Reduced WS_BUFFER_SIZE default from ~800ms (25600 bytes) to ~450ms (14400 bytes)
- Reduced WS_OVERLAP_SIZE proportionally from ~300ms (9600 bytes) to ~150ms (4800 bytes)
- Updated comments, docstrings, and CLAUDE.md environment variable table

## Why
Lower buffer size means faster partial transcription results, reducing perceived latency from ~800ms to ~450ms per chunk.

## Test
```bash
docker compose up -d --build
# Connect WS client, send audio in small chunks
# Verify: partial results arrive ~450ms after audio starts (vs 800ms before)
```

Tests: 0 passed, 0 failed, 0 skipped (manual verification only)