### PR TITLE
[Enhancement] Eliminate unnecessary bytes() copy in WS transcription

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -511,7 +511,7 @@ async def _transcribe_with_context(
             return ""
 
         # Convert to numpy float32
-        audio = np.frombuffer(bytes(full_audio), dtype=np.int16)
+        audio = np.frombuffer(full_audio, dtype=np.int16)
         audio = audio.astype(np.float32) / 32768.0
 
         # Preprocess (mono, normalize)

--- a/src/server_test.py
+++ b/src/server_test.py
@@ -59,3 +59,13 @@
 #   # Run multiple requests in succession to confirm no memory leak
 #   curl http://localhost:8100/health  # check GPU memory stays stable
 # Expected: faster inference (5-10ms saved per request), same transcription quality
+
+# ─── Issue #16: Eliminate unnecessary bytes() copy in WS transcription ─────
+# Change: Replaced np.frombuffer(bytes(full_audio), ...) with
+#         np.frombuffer(full_audio, ...) in _transcribe_with_context().
+#         bytearray is directly supported by np.frombuffer — no copy needed.
+# Verify:
+#   docker compose up -d --build
+#   # Use WebSocket client from docs/WEBSOCKET_USAGE.md to stream audio
+#   # Compare transcription output — should be identical
+# Expected: eliminates one full buffer copy per WS chunk, same transcription quality


### PR DESCRIPTION
Closes #16

## What
In `_transcribe_with_context()`, replaced:
```python
audio = np.frombuffer(bytes(full_audio), dtype=np.int16)
```
with:
```python
audio = np.frombuffer(full_audio, dtype=np.int16)
```

`bytearray` is directly supported by `np.frombuffer` — the `bytes()` wrapper creates an unnecessary full copy of the audio buffer for every WebSocket chunk.

## Test
```bash
docker compose up -d --build
# Use WebSocket client from docs/WEBSOCKET_USAGE.md to stream audio
# Compare transcription output — should be identical
```
Expected: eliminates one full buffer copy per WS chunk, same transcription quality