### PR TITLE
[Enhancement] Optimize WebSocket audio preprocessing fast path

### DIFF
--- a/src/server_test.py
+++ b/src/server_test.py
@@ -69,3 +69,14 @@
 #   # Use WebSocket client from docs/WEBSOCKET_USAGE.md to stream audio
 #   # Compare transcription output — should be identical
 # Expected: eliminates one full buffer copy per WS chunk, same transcription quality
+
+# ─── Issue #15: Optimize WebSocket audio preprocessing path ───────────────
+# Change: Added preprocess_audio_ws() fast path that only does peak normalization.
+#         Replaced preprocess_audio(audio, TARGET_SR) call in _transcribe_with_context()
+#         with preprocess_audio_ws(audio) since WS audio is already mono, float32, 16kHz.
+# Verify:
+#   docker compose up -d --build
+#   # Use WebSocket client from docs/WEBSOCKET_USAGE.md to stream audio
+#   curl -X POST http://localhost:8100/v1/audio/transcriptions -F "file=@audio.wav"
+#   # Both HTTP and WS should produce correct transcriptions
+# Expected: faster WS transcription (skips redundant mono/resample/cast), same quality


### PR DESCRIPTION
Closes #15

## What
Added `preprocess_audio_ws()` function that only performs peak normalization for WebSocket audio. WebSocket PCM arriving in `_transcribe_with_context()` is already:
- Mono (PCM from WS is always single-channel)
- At 16kHz (client sends 16kHz PCM)
- float32 (after `/32768.0` division)

The full `preprocess_audio()` call was doing redundant work: mono check, float32 cast, no-op resample, and re-normalization.

The new fast path skips all of that and only does peak normalization.

## Test
```bash
docker compose up -d --build
# Test WS: use Python client from docs/WEBSOCKET_USAGE.md
# Test HTTP: curl -X POST http://localhost:8100/v1/audio/transcriptions -F "file=@audio.wav"
# Both paths should produce correct transcriptions
```
Expected: faster WS transcription, same quality. HTTP path unchanged.