### PR TITLE
issue #25: Integrate Silero VAD for voice activity detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN pip install --no-cache-dir \
     uvicorn \
     python-multipart \
     websockets \
+    silero-vad \
     "git+https://github.com/QwenLM/Qwen3-ASR.git"
 
 # Flash Attention 2 (built from source for CUDA 12.4 compatibility)

--- a/src/server_test.py
+++ b/src/server_test.py
@@ -164,3 +164,8 @@
 # Verify: Upload a >30s audio file
 #   curl -X POST http://localhost:8100/v1/audio/transcriptions -F "file=@long_audio.wav"
 # Expected: correct transcription without quality degradation
+
+# ─── Issue #25: Silero VAD ───────────────────────────────────────────
+# Change: WS transcription skips silent frames
+# Verify: docker compose logs | grep "Silero VAD loaded"
+# Test: send silent audio via WS — should get empty response without GPU inference


### PR DESCRIPTION
Closes #25

## What
- Added Silero VAD integration to gate WebSocket transcription
- Silent audio frames skip GPU inference entirely, saving compute
- VAD model loaded lazily at ASR model startup (CPU-only, ~1MB)
- Safe fallbacks: assumes speech if silero-vad not installed or VAD fails
- Added `silero-vad` to Dockerfile pip dependencies

## Changes
- `src/server.py`: Added `_load_vad()`, `is_speech()` functions; VAD gate in `_transcribe_with_context()`
- `Dockerfile`: Added `silero-vad` to pip install

## Test
```bash
docker compose up -d --build
docker compose logs | grep "Silero VAD loaded"
# Send silent audio via WS — should get empty response without GPU inference
# Send speech audio via WS — should transcribe normally
```

Tests: 0 passed, 0 failed, 0 skipped (manual verification only)