### PR TITLE
issue #37: TensorRT conversion for encoder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,13 @@ RUN pip install --no-cache-dir torchao
 # Flash Attention 2 (built from source for CUDA 12.4 compatibility)
 RUN pip install --no-cache-dir flash-attn --no-build-isolation
 
+# Optional: install torch-tensorrt for TRT encoder support
+# RUN pip install --no-cache-dir torch-tensorrt
+
 COPY src/server.py /app/server.py
 COPY src/gateway.py /app/gateway.py
 COPY src/worker.py /app/worker.py
+COPY src/build_trt.py /app/build_trt.py
 
 EXPOSE 8000
 

--- a/src/build_trt.py
+++ b/src/build_trt.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Build TensorRT engine for Qwen3-ASR encoder.
+Usage: python src/build_trt.py --output models/encoder.trt
+Requires: torch-tensorrt
+"""
+import argparse
+import os
+import torch
+import numpy as np
+
+
+def build_trt_engine(model_id: str, output_path: str):
+    try:
+        import torch_tensorrt
+    except ImportError:
+        print("torch-tensorrt not installed. Run: pip install torch-tensorrt")
+        return
+
+    from qwen_asr import Qwen3ASRModel
+    print(f"Loading {model_id}...")
+    model = Qwen3ASRModel.from_pretrained(
+        model_id, torch_dtype=torch.float16, device_map="cuda",
+        trust_remote_code=True
+    )
+    model.eval()
+
+    encoder = getattr(model, 'encoder', None) or getattr(
+        getattr(model, 'model', None), 'encoder', None
+    )
+    if encoder is None:
+        print("Cannot find encoder submodule")
+        return
+
+    dummy = torch.randn(1, 80, 3000, dtype=torch.float16, device="cuda")
+
+    trt_model = torch_tensorrt.compile(
+        encoder,
+        inputs=[torch_tensorrt.Input(
+            min_shape=(1, 80, 500),
+            opt_shape=(1, 80, 1500),
+            max_shape=(1, 80, 3000),
+            dtype=torch.float16,
+        )],
+        enabled_precisions={torch.float16},
+    )
+
+    os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
+    torch.jit.save(torch.jit.trace(trt_model, dummy), output_path)
+    print(f"TensorRT engine saved to {output_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-id", default=os.getenv("MODEL_ID", "Qwen/Qwen3-ASR-1.7B"))
+    parser.add_argument("--output", default="models/encoder.trt")
+    args = parser.parse_args()
+    build_trt_engine(args.model_id, args.output)

--- a/src/server_test.py
+++ b/src/server_test.py
@@ -304,3 +304,35 @@ def test_vllm_loader_exists():
 def test_vllm_infer_exists():
     from server import _do_transcribe_vllm
     assert callable(_do_transcribe_vllm)
+
+# ─── Issue #37: TensorRT encoder conversion ──────────────────────────
+# Change: TRT_ENCODER_PATH enables TensorRT-optimized encoder inference.
+#         New script src/build_trt.py builds the TRT engine.
+# Verify:
+#   python src/build_trt.py --output models/encoder.trt
+#   TRT_ENCODER_PATH=models/encoder.trt docker compose up -d --build
+#   docker compose logs | grep "TensorRT"
+# Expected: "TensorRT encoder loaded from models/encoder.trt"
+
+
+def test_trt_loader_exists():
+    """Verify TRT encoder loader function exists."""
+    from server import _try_load_trt_encoder
+    assert callable(_try_load_trt_encoder)
+
+def test_trt_encoder_global():
+    """Verify _trt_encoder global is defined."""
+    from server import _trt_encoder
+    assert _trt_encoder is None
+
+def test_build_trt_importable():
+    """Verify build_trt module is importable."""
+    import build_trt
+    assert callable(build_trt.build_trt_engine)
+
+def test_do_transcribe_has_trt_path():
+    """Verify _do_transcribe references _trt_encoder for integration."""
+    import inspect
+    from server import _do_transcribe
+    source = inspect.getsource(_do_transcribe)
+    assert "_trt_encoder" in source


### PR DESCRIPTION
Closes #37

## What
- Add `src/build_trt.py` - script to build TensorRT engine for the ASR encoder
- Add `_try_load_trt_encoder()` in server.py to load pre-built TRT engine at startup
- Controlled via `TRT_ENCODER_PATH` env var (path to `.trt` file)
- Add commented `torch-tensorrt` install in Dockerfile (large dependency, user opts in)
- Copy `build_trt.py` into container for in-container builds

## Test
- Build: `python src/build_trt.py --output models/encoder.trt`
- Enable: `TRT_ENCODER_PATH=models/encoder.trt docker compose up -d --build`
- Verify: `docker compose logs -f` should show "TensorRT encoder loaded"