### PR TITLE
issue #27: priority scheduling for WebSocket vs HTTP

### DIFF
--- a/src/server_test.py
+++ b/src/server_test.py
@@ -169,3 +169,13 @@
 # Change: WS transcription skips silent frames
 # Verify: docker compose logs | grep "Silero VAD loaded"
 # Test: send silent audio via WS — should get empty response without GPU inference
+
+# ─── Issue #27: Priority scheduling for WebSocket vs HTTP ───────────
+# Change: Replaced asyncio.Semaphore(1) with PriorityInferQueue.
+#         WS requests get priority=0 (higher), HTTP gets priority=1 (lower).
+#         Uses min-heap so WS jobs run first when multiple are queued.
+# Verify:
+#   docker compose up -d --build
+#   curl -X POST http://localhost:8100/v1/audio/transcriptions -F "file=@audio.wav"
+#   # Start WS stream while HTTP is processing — WS should not be blocked
+# Expected: WS transcription completes even while HTTP request is in progress


### PR DESCRIPTION
Closes #27

## What
Replace global `asyncio.Semaphore(1)` with `PriorityInferQueue` — a min-heap-based inference scheduler that gives WebSocket requests (priority=0) precedence over HTTP file uploads (priority=1). When multiple requests are queued, real-time WS transcription runs first.

Key changes:
- Added `_InferJob` dataclass and `PriorityInferQueue` class with single-worker async worker loop
- HTTP `/v1/audio/transcriptions` uses `priority=1` (lower)
- WebSocket `_transcribe_with_context` uses `priority=0` (higher)  
- Queue lifecycle managed via ASGI lifespan (start on startup, stop on shutdown)
- Removed `_infer_semaphore` entirely

## Test
- `curl -X POST http://localhost:8100/v1/audio/transcriptions -F "file=@audio.wav"` — HTTP still works
- WebSocket connect + flush — WS still works
- Concurrent HTTP + WS — WS completes first when queued