### PR TITLE
issue #36: Adopt vLLM engine backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN pip install --no-cache-dir \
     bitsandbytes \
     onnxruntime-gpu \
     aiohttp \
+    # vllm \  # Uncomment for USE_VLLM=true support (large dependency)
     "git+https://github.com/QwenLM/Qwen3-ASR.git"
 
 # torchao for FP8 quantization (opt-in via QUANTIZE=fp8)

--- a/src/server_test.py
+++ b/src/server_test.py
@@ -282,3 +282,25 @@ def test_worker_reuses_server_code():
     import worker
     import server
     assert worker.preprocess_audio is server.preprocess_audio
+
+# ─── Issue #36: vLLM engine backend ──────────────────────────────────
+# Change: USE_VLLM=true enables vLLM engine for inference (requires vllm pip package)
+# Verify:
+#   Set USE_VLLM=true in docker-compose.yml (uncomment vllm in Dockerfile)
+#   docker compose up -d --build
+#   docker compose logs | grep "vLLM"
+# Expected: "vLLM engine loaded" or fallback to PyTorch
+
+
+def test_vllm_globals():
+    from server import _vllm_engine, USE_VLLM
+    assert _vllm_engine is None
+    assert isinstance(USE_VLLM, bool)
+
+def test_vllm_loader_exists():
+    from server import _load_vllm_engine
+    assert callable(_load_vllm_engine)
+
+def test_vllm_infer_exists():
+    from server import _do_transcribe_vllm
+    assert callable(_do_transcribe_vllm)


### PR DESCRIPTION
Closes #36

## What
- Add opt-in vLLM engine backend for batched inference with PagedAttention
- Controlled via USE_VLLM=true env var
- Graceful fallback to native loader on failure

## Test
- Uncomment vllm in Dockerfile, set USE_VLLM=true, rebuild
- curl -X POST http://localhost:8100/v1/audio/transcriptions -F "file=@audio.wav"