### PR TITLE
issue #33: dual-model strategy for WS partials vs finals

### DIFF
--- a/src/server_test.py
+++ b/src/server_test.py
@@ -223,3 +223,13 @@
 #   # Connect via WS, send multiple audio chunks, verify transcription
 #   # Send {"action": "reset"} to clear cache between sessions
 # Expected: faster subsequent WS chunks, same transcription quality
+
+# ─── Issue #33: Dual-model strategy (0.6B partials, 1.7B finals) ────
+# Change: When DUAL_MODEL=true, loads 0.6B model for fast WS partials
+#         and configured model for final flush results.
+# Verify:
+#   Set DUAL_MODEL=true in docker-compose.yml environment
+#   docker compose up -d --build
+#   docker compose logs | grep -i "dual\|fast model"
+#   Expected: "Dual-model strategy enabled"
+# Without DUAL_MODEL=true: single model behavior (default)


### PR DESCRIPTION
Closes #33

## What
Load both 0.6B (fast) and configured model (accurate) when `DUAL_MODEL=true`:
- Partial WS transcriptions use the fast 0.6B model (`use_fast=True`)
- Final flush transcriptions use the full configured model (`use_fast=False`)
- Added `_fast_model` global and `use_fast` parameter to `_do_transcribe()`
- Without `DUAL_MODEL=true`, behavior is unchanged (single model)

## Test
- `DUAL_MODEL=true MODEL_ID=Qwen/Qwen3-ASR-1.7B` -- logs show dual model loading
- WS partials use fast model, flush uses full model
- Without env var, single model behavior preserved