### PR TITLE
fix: remove duplicate _infer_executor from Phase 2 milestone

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -106,13 +106,6 @@ _fast_model_id = "Qwen/Qwen3-ASR-0.6B"
 # Lock to prevent concurrent load/unload
 _model_lock = asyncio.Lock()
 
-# Dedicated single-threaded executor for GPU inference
-# Ensures inference always runs on the same OS thread (better GPU context affinity)
-_infer_executor = concurrent.futures.ThreadPoolExecutor(
-    max_workers=1,
-    thread_name_prefix="qwen3-asr-infer",
-)
-
 # Request timeout in seconds
 REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", "300"))
 


### PR DESCRIPTION
## Summary

- PR #68 (priority queue) added a self-contained _infer_executor because it was originally written against the Phase 2 base before Phase 1 was rebased in
- After milestone/phase-2 was rebased onto Phase 1, two ThreadPoolExecutors were created at module load — leaking the first one
- Removes the duplicate second definition (7 lines), keeping only the Phase 1 definition at line 35

## Test plan
- [ ] grep "_infer_executor" src/server.py shows exactly one assignment
- [ ] docker compose up -d --build starts without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)