### PR TITLE
Closes #93: add realtime pytest marker

### DIFF
--- a/E2Etest/pytest.ini
+++ b/E2Etest/pytest.ini
@@ -16,6 +16,7 @@ markers =
     accuracy: Transcription accuracy tests
     benchmark: Benchmark tests with saved results
     requires_gpu: Tests requiring GPU
+    realtime: Real-time latency and accuracy benchmarks (streams audio via WebSocket)
 
 # Warnings
 filterwarnings =


### PR DESCRIPTION
Closes #93

Adds the `realtime` marker to `E2Etest/pytest.ini` so `@pytest.mark.realtime` in `test_realtime_accuracy.py` does not trigger `PytestUnknownMarkWarning` under `--strict-markers`.